### PR TITLE
fix public-ipv6 from mesh is used as defaultroute to connect to fastd-se...

### DIFF
--- a/files/default/etc/freifunk/rc.local
+++ b/files/default/etc/freifunk/rc.local
@@ -72,6 +72,8 @@ if [ "`uci -q get freifunk.fw.confver`" == "0" ] ; then
   uci set network.l2mesh.ifname="bat0 $lanif"
   uci set network.l2mesh.auto='1'
   uci set network.l2mesh.accept_ra='0'
+  uci set network.l2mesh.reqprefix='no'
+  uci set network.l2mesh.defaultroute='0'
   uci set network.l2mesh.ip6addr="$IPV6"
   uci set network.l2mesh.ipaddr="$local_ip"
   uci set network.l2mesh.macaddr="$brmac"


### PR DESCRIPTION
...rvers
