### PR TITLE
redirect output of fwupgrade to tmp-file

### DIFF
--- a/files/default/etc/crontabs/root
+++ b/files/default/etc/crontabs/root
@@ -1,5 +1,5 @@
 */5    * * * * sh /usr/sbin/ff-stats
-0      4 * * * sh /usr/sbin/ff-fwupgrade
+0      4 * * * sh /usr/sbin/ff-fwupgrade 2>&1 > /tmp/last-fwupgrade
 */15   * * * * sh /usr/sbin/ff-rebootIfNoGw
 */15   * * * * sh /usr/sbin/ff-rebootIfNoWifiMeshAnymore
 */2    * * * * sh /usr/sbin/ff-offline-ssid.sh 60


### PR DESCRIPTION
it seems that the process is killed if it tries to write to stdout and no redirection is there
